### PR TITLE
Patrolroutes and Cave encounter bugs

### DIFF
--- a/PReloaded/Server/maps/e_cave1in.fomap
+++ b/PReloaded/Server/maps/e_cave1in.fomap
@@ -2,8 +2,8 @@
 Version              4
 MaxHexX              149
 MaxHexY              147
-WorkHexX             75
-WorkHexY             82
+WorkHexX             60
+WorkHexY             81
 ScriptModule         map_random_cave
 ScriptFunc           map_init
 NoLogOut             0
@@ -11576,7 +11576,7 @@ Scenery_ToEntire     11
 MapObjType           2
 ProtoId              3853
 MapX                 64
-MapY                 83
+MapY                 82
 Scenery_ToEntire     11
 
 MapObjType           2
@@ -11755,8 +11755,8 @@ Scenery_ToEntire     10
 
 MapObjType           2
 ProtoId              3853
-MapX                 64
-MapY                 80
+MapX                 62
+MapY                 84
 Scenery_ToEntire     20
 
 MapObjType           2

--- a/PReloaded/Server/maps/e_cave3in.fomap
+++ b/PReloaded/Server/maps/e_cave3in.fomap
@@ -2,8 +2,8 @@
 Version              4
 MaxHexX              239
 MaxHexY              197
-WorkHexX             143
-WorkHexY             78
+WorkHexX             67
+WorkHexY             136
 ScriptModule         map_random_cave
 ScriptFunc           map_init
 NoLogOut             0
@@ -15319,8 +15319,8 @@ MapY                 130
 
 MapObjType           2
 ProtoId              3853
-MapX                 64
-MapY                 130
+MapX                 62
+MapY                 134
 Scenery_ToEntire     20
 
 MapObjType           2
@@ -15501,7 +15501,7 @@ MapY                 132
 MapObjType           2
 ProtoId              3853
 MapX                 64
-MapY                 133
+MapY                 132
 Scenery_ToEntire     11
 
 MapObjType           2

--- a/PReloaded/Server/maps/e_cave6in.fomap
+++ b/PReloaded/Server/maps/e_cave6in.fomap
@@ -2,8 +2,8 @@
 Version              4
 MaxHexX              237
 MaxHexY              200
-WorkHexX             106
-WorkHexY             105
+WorkHexX             149
+WorkHexY             79
 ScriptModule         map_random_cave
 ScriptFunc           map_init
 NoLogOut             0
@@ -13906,7 +13906,7 @@ Scenery_ToEntire     11
 MapObjType           2
 ProtoId              3853
 MapX                 152
-MapY                 83
+MapY                 82
 Scenery_ToEntire     11
 
 MapObjType           2
@@ -14085,8 +14085,8 @@ Scenery_ToEntire     10
 
 MapObjType           2
 ProtoId              3853
-MapX                 152
-MapY                 80
+MapX                 150
+MapY                 84
 Scenery_ToEntire     20
 
 MapObjType           2

--- a/PReloaded/Server/scripts/junktown_guard.fos
+++ b/PReloaded/Server/scripts/junktown_guard.fos
@@ -50,7 +50,7 @@ void _Idle(Critter& guard)
 
     if(guard.Stat[ST_NPC_ROLE] == ROLE_JNK_GUARD_1)
     {
-        _GetNextNode(guard, 10)         // Route 10 as defined in patrolroutes.fos
+        _GetNextNode(guard, 17)         // Route 17 as defined in patrolroutes.fos
     }
 
     if(IsPatrolling(guard))

--- a/PReloaded/Server/scripts/ncr_guard.fos
+++ b/PReloaded/Server/scripts/ncr_guard.fos
@@ -48,7 +48,7 @@ void _Idle(Critter& guard)
 
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PATROL1)
         {
-            _GetNextNode(guard, 13)         // Route 13 as defined in patrolroutes.fos
+            _GetNextNode(guard, 20)         // Route 20 as defined in patrolroutes.fos
         }
 
         if(IsPatrolling(guard))

--- a/PReloaded/Server/scripts/ncr_guard_prison.fos
+++ b/PReloaded/Server/scripts/ncr_guard_prison.fos
@@ -75,55 +75,55 @@ void _Idle(Critter& guard)
         // NCR PRISON GUARDS START
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL1)
         {
-            _GetNextNode(guard, 14)
+            _GetNextNode(guard, 21)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL2)
         {
-            _GetNextNode(guard, 15)
+            _GetNextNode(guard, 22)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL3)
         {
-            _GetNextNode(guard, 16)
+            _GetNextNode(guard, 23)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL4)
         {
-            _GetNextNode(guard, 17)
+            _GetNextNode(guard, 24)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL5)
         {
-            _GetNextNode(guard, 18)
+            _GetNextNode(guard, 25)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL6)
         {
-            _GetNextNode(guard, 19)
+            _GetNextNode(guard, 26)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL7)
         {
-            _GetRandomNode(guard, 20)
+            _GetRandomNode(guard, 27)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL8)
         {
-            _GetNextNode(guard, 21)
+            _GetNextNode(guard, 28)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL9)
         {
-            _GetNextNode(guard, 22)
+            _GetNextNode(guard, 29)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL10)
         {
-            _GetNextNode(guard, 23)
+            _GetNextNode(guard, 30)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL11)
         {
-            _GetNextNode(guard, 24)
+            _GetNextNode(guard, 31)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL12)
         {
-            _GetNextNode(guard, 25)
+            _GetNextNode(guard, 32)
         }
         if(guard.Stat[ST_NPC_ROLE] == ROLE_NCR_GUARD_PRISON_PATROL13)
         {
-            _GetNextNode(guard, 26)
+            _GetNextNode(guard, 33)
         }
         // NCR PRISON GUARDS END
 

--- a/PReloaded/Server/scripts/patrolroutes.fos
+++ b/PReloaded/Server/scripts/patrolroutes.fos
@@ -51,7 +51,7 @@ void InitRoutes()
               .AddNode(130, 141, 0, 23000)
               .AddNode(100, 116, 5, 31000)
               .AddNode(91, 82, 5, 27000)
-              .AddNode(107, 80, 3, 25000));                                                                    // id 2
+              .AddNode(107, 80, 3, 25000));                                                                     // id 2
 
     // ===================================
     // Hub routes
@@ -141,7 +141,7 @@ void InitRoutes()
               .AddNode(12, 2, 60000)
               .AddNode(13, 2, 80000)
               .AddNode(14, 2, 40000)
-              .AddNode(15, 2, 60000));     // id 10
+              .AddNode(15, 2, 60000));     // id 17
 
     // ===================================
     // VCity routes
@@ -159,13 +159,13 @@ void InitRoutes()
               .AddNode(4, 4, 30000)
               .AddNode(3, 1, 40000)
               .AddNode(2, 5, 30000)
-              .AddNode(1, 1, 60000));     // id 11
+              .AddNode(1, 1, 60000));     // id 18
 
     ADD_ROUTE(VC_GUARD_PATROL2, MAP_VaultCityDowntown, AddNode(10, 4, 60000)
               .AddNode(11, 5, 60000)
               .AddNode(12, 1, 60000)
               .AddNode(13, 2, 60000)
-              .AddNode(14, 3, 60000));     // id 12
+              .AddNode(14, 3, 60000));     // id 19
 
     // ===================================
     // NCR routes
@@ -179,7 +179,7 @@ void InitRoutes()
               .AddNode(7, 2, 40000)
               .AddNode(8, 3, 30000)
               .AddNode(9, 2, 10000)
-              .AddNode(10, 2, 50000));     // id 13
+              .AddNode(10, 2, 50000));     // id 20
 
     // ===================================
     // NCR Prison routes
@@ -189,36 +189,36 @@ void InitRoutes()
               .AddNode(3, 3, 60000)
               .AddNode(4, 3, 50000)
               .AddNode(3, 3, 50000)
-              .AddNode(2, 2, 40000));     // id 14
+              .AddNode(2, 2, 40000));     // id 21
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL2, MAP_NCRCF, AddNode(4, 3, 40000)
               .AddNode(5, 3, 60000)
               .AddNode(6, 5, 40000)
-              .AddNode(5, 3, 60000));     // id 15
+              .AddNode(5, 3, 60000));     // id 22
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL3, MAP_NCRCF, AddNode(6, 5, 50000)
               .AddNode(7, 5, 60000)
               .AddNode(8, 5, 40000)
               .AddNode(9, 5, 50000)
               .AddNode(8, 5, 50000)
-              .AddNode(7, 5, 60000));     // id 16
+              .AddNode(7, 5, 60000));     // id 23
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL4, MAP_NCRCF, AddNode(9, 5, 40000)
               .AddNode(8, 5, 60000)
               .AddNode(7, 5, 40000)
               .AddNode(6, 5, 40000)
               .AddNode(7, 5, 40000)
-              .AddNode(8, 5, 60000));     // id 17
+              .AddNode(8, 5, 60000));     // id 24
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL5, MAP_NCRCF, AddNode(10, 0, 40000)
               .AddNode(11, 0, 60000)
               .AddNode(12, 1, 40000)
-              .AddNode(11, 0, 60000));     // id 18
+              .AddNode(11, 0, 60000));     // id 25
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL6, MAP_NCRCF, AddNode(13, 1, 50000)
               .AddNode(14, 2, 60000)
               .AddNode(15, 2, 40000)
-              .AddNode(14, 2, 60000));     // id 19
+              .AddNode(14, 2, 60000));     // id 26
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL7, MAP_NCRCF, AddNode(16, 3, 50000)
               .AddNode(17, 4, 50000)
@@ -226,7 +226,7 @@ void InitRoutes()
               .AddNode(19, 0, 50000)
               .AddNode(20, 0, 60000)
               .AddNode(21, 1, 50000)
-              .AddNode(22, 3, 50000));     // id 20
+              .AddNode(22, 3, 50000));     // id 27
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL8, MAP_NCRCF, AddNode(1, 3, 50000)
               .AddNode(2, 2, 50000)
@@ -242,26 +242,26 @@ void InitRoutes()
               .AddNode(12, 0, 50000)
               .AddNode(13, 2, 50000)
               .AddNode(14, 2, 50000)
-              .AddNode(15, 2, 50000));     // id 21
+              .AddNode(15, 2, 50000));     // id 28
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL9, MAP_Rails, AddNode(16, 0, 50000)
               .AddNode(17, 0, 50000)
               .AddNode(18, 5, 50000)
-              .AddNode(17, 2, 50000));     // id 22
+              .AddNode(17, 2, 50000));     // id 29
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL10, MAP_Rails, AddNode(11, 4, 50000)
               .AddNode(18, 3, 50000)
               .AddNode(17, 0, 50000)
               .AddNode(16, 4, 50000)
               .AddNode(17, 2, 60000)
-              .AddNode(18, 3, 50000));     // id 23
+              .AddNode(18, 3, 50000));     // id 30
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL11, MAP_Rails, AddNode(1, 1, 50000)
               .AddNode(2, 1, 50000)
               .AddNode(3, 0, 50000)
               .AddNode(4, 0, 50000)
               .AddNode(3, 0, 60000)
-              .AddNode(2, 1, 50000));     // id 24
+              .AddNode(2, 1, 50000));     // id 31
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL12, MAP_Rails, AddNode(15, 3, 50000)
               .AddNode(14, 3, 50000)
@@ -272,7 +272,7 @@ void InitRoutes()
               .AddNode(11, 3, 50000)
               .AddNode(12, 3, 50000)
               .AddNode(13, 3, 50000)
-              .AddNode(14, 3, 50000));     // id 25
+              .AddNode(14, 3, 50000));     // id 32
 
     ADD_ROUTE(NCR_GUARD_PRISON_PATROL13, MAP_Rails, AddNode(9, 5, 60000)
               .AddNode(8, 0, 50000)
@@ -281,7 +281,7 @@ void InitRoutes()
               .AddNode(5, 0, 60000)
               .AddNode(6, 0, 60000)
               .AddNode(7, 0, 50000)
-              .AddNode(8, 0, 50000));     // id 26
+              .AddNode(8, 0, 50000));     // id 33
 
     // Add more...
 

--- a/PReloaded/Server/scripts/vaul_guard.fos
+++ b/PReloaded/Server/scripts/vaul_guard.fos
@@ -99,11 +99,11 @@ void _Idle(Critter& guard)
 
         if(guard.Stat[ST_NPC_ROLE] == ROLE_VC_GUARD_PATROL1)
         {
-            _GetNextNode(guard, 11)         // Route 11 as defined in patrolroutes.fos
+            _GetNextNode(guard, 18)         // Route 18 as defined in patrolroutes.fos
         }
         else if(guard.Stat[ST_NPC_ROLE] == ROLE_VC_GUARD_PATROL2)
         {
-            _GetNextNode(guard, 12)         // Route 12 as defined in patrolroutes.fos
+            _GetNextNode(guard, 19)         // Route 19 as defined in patrolroutes.fos
         }
 
         if(IsPatrolling(guard))


### PR DESCRIPTION
minor fixes:
- after adding new patrolroutes to the Hub parking lot the order of the routes has changed, I'm adding fix order.
- in cave encounters 1/3/6 the entries for spawn items were placed behind the wall from where it is not possible to take the item , I am adding the moved entries
![e cave entries1](https://github.com/user-attachments/assets/e7cf36ba-2232-4528-b403-7c67edbd7b68)
![e cave entries2](https://github.com/user-attachments/assets/44eb0863-9d23-4f44-9d78-504101019806)
